### PR TITLE
Project 1 updates.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ SOURCE_DIR = .
 all: submit
 
 submit:
+	rm -rf $(ZIP_TMP_DIR)
 	rm -f $(ZIP_FILE)
 	rsync -av --exclude-from=$(SOURCE_DIR)/.gitignore --exclude-from=$(SOURCE_DIR)/calcite_app/.gitignore --exclude '.git' $(SOURCE_DIR)/ $(ZIP_TMP_DIR)
+	cp calcite_app/gradle/wrapper/gradle-wrapper.jar $(ZIP_TMP_DIR)/calcite_app/gradle/wrapper/gradle-wrapper.jar
 	cd $(ZIP_TMP_DIR) && zip -r $(ZIP_FILE) .
 	mv $(ZIP_TMP_DIR)/$(ZIP_FILE) $(ZIP_FILE)
 	rm -rf $(ZIP_TMP_DIR)

--- a/calcite_app/gradle.properties
+++ b/calcite_app/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.configuration-cache=true
 calcite.version=1.38.0
+org.gradle.jvmargs=-Xms64m -Xmx512m

--- a/calcite_app/src/main/java/edu/cmu/cs/db/calcite_app/app/App.java
+++ b/calcite_app/src/main/java/edu/cmu/cs/db/calcite_app/app/App.java
@@ -1,7 +1,45 @@
 package edu.cmu.cs.db.calcite_app.app;
 
+import java.io.File;
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.nio.file.Files;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.SqlExplainFormat;
+import org.apache.calcite.sql.SqlExplainLevel;
+
 public class App
 {
+    private static void SerializePlan(RelNode relNode, File outputPath) throws IOException {
+        Files.writeString(outputPath.toPath(), RelOptUtil.dumpPlan("", relNode, SqlExplainFormat.TEXT, SqlExplainLevel.ALL_ATTRIBUTES));
+    }
+
+    private static void SerializeResultSet(ResultSet resultSet, File outputPath) throws SQLException, IOException {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int columnCount = metaData.getColumnCount();
+        StringBuilder resultSetString = new StringBuilder();
+        for (int i = 1; i <= columnCount; i++) {
+            if (i > 1) {
+                resultSetString.append(", ");
+            }
+            resultSetString.append(metaData.getColumnName(i));
+        }
+        resultSetString.append("\n");
+        while (resultSet.next()) {
+            for (int i = 1; i <= columnCount; i++) {
+                if (i > 1) {
+                    resultSetString.append(", ");
+                }
+                resultSetString.append(resultSet.getString(i));
+            }
+            resultSetString.append("\n");
+        }
+        Files.writeString(outputPath.toPath(), resultSetString.toString());
+    }
+
     public static void main(String[] args) throws Exception
     {
         if (args.length == 0) {

--- a/optimize.sh
+++ b/optimize.sh
@@ -10,7 +10,6 @@ echo -e "\tWorkload: ${WORKLOAD}"
 echo -e "\tOutput Dir: ${OUTPUT_DIR}"
 
 mkdir -p "${OUTPUT_DIR}"
-
 mkdir -p input/
 
 # Extract the workload.
@@ -22,5 +21,6 @@ tar xzf "${WORKLOAD}" --directory input/
 cd calcite_app/
 ./gradlew build
 ./gradlew shadowJar
-java -jar build/libs/calcite_app-1.0-SNAPSHOT-all.jar "./input/" "${OUTPUT_DIR}"
+./gradlew --stop
+java -Xmx4096m -jar build/libs/calcite_app-1.0-SNAPSHOT-all.jar "../input/queries" "../${OUTPUT_DIR}"
 cd -

--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,10 @@ set -euxo pipefail
 sudo apt install openjdk-17-jdk
 
 # Download and extract DuckDB.
-wget https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip
+wget --quiet https://github.com/duckdb/duckdb/releases/download/v1.1.3/duckdb_cli-linux-amd64.zip
 unzip duckdb_cli-linux-amd64.zip
 rm duckdb_cli-linux-amd64.zip
 
 # Download the workload.
 # Note: currently hosted on Wan's Google Drive, link may be subject to change.
-wget --no-check-certificate -r 'https://drive.usercontent.google.com/download?export=download&id=1f4HtlX6Y363VpmKJUmAhkdoXcfpUx_OP&confirm=yes' -O workload.tgz
+wget --quiet --no-check-certificate -r 'https://drive.usercontent.google.com/download?export=download&id=1f4HtlX6Y363VpmKJUmAhkdoXcfpUx_OP&confirm=yes' -O workload.tgz

--- a/setup.sh
+++ b/setup.sh
@@ -10,5 +10,4 @@ unzip duckdb_cli-linux-amd64.zip
 rm duckdb_cli-linux-amd64.zip
 
 # Download the workload.
-# Note: currently hosted on Wan's Google Drive, link may be subject to change.
-wget --quiet --no-check-certificate -r 'https://drive.usercontent.google.com/download?export=download&id=1f4HtlX6Y363VpmKJUmAhkdoXcfpUx_OP&confirm=yes' -O workload.tgz
+wget --quiet https://db.cs.cmu.edu/files/15799-s25/workload.tgz


### PR DESCRIPTION
Various fixes for project 1.

- Fix make submit to include gradle-wrapper jar.
- Constrain memory usage for Gradle JVM.
- Limit optimize.sh RAM usage by stopping gradle and setting Xmx.
- Update App.java starter code with plan and ResultSet serialization.
- Silence wget output in setup.sh.
- Change workload url.